### PR TITLE
Downgrade matrix version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,5 +68,5 @@ Suggests:
     circlize
 Config/testthat/edition: 3
 Remotes:
-    cran/Matrix@1.6-5,
+    cran/Matrix@1.6-1.1,
     cran/MASS@7.3-60


### PR DESCRIPTION
Using Matrix version 1.6.5 with Seurat version 4.4.0 breaks `Seurat::FindNeighbors`.

The `env.yml` for GaitiLab's Seurat v4 sif should also be changed accordingly and the sif rebuilt.